### PR TITLE
Use Playwright CLI for screenshots

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 public/main.js
 .deno/
+.deno-runtime/
+.playwright-browsers/
+artifacts/
 .DS_Store

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,11 +1,20 @@
 # Agent Notes
 
 ## Deno setup
-- If `deno` is missing, run `./scripts/install-deno.sh` and add `./.deno-runtime/bin` to your `PATH` for the session (`export PATH="$(pwd)/.deno-runtime/bin:$PATH"`).
-- All project tasks set `DENO_TLS_CA_STORE=system` so dependency downloads work inside the Codex container.
-- Run `./scripts/install-playwright-deps.sh` once per container to install the system libraries Chromium needs.
+
+- If `deno` is missing, run `./scripts/install-deno.sh` and add `./.deno-runtime/bin` to your `PATH`
+  for the session (`export PATH="$(pwd)/.deno-runtime/bin:$PATH"`).
+- All project tasks set `DENO_TLS_CA_STORE=system` so dependency downloads work inside the Codex
+  container.
+- Run `./scripts/install-playwright-deps.sh` once per container to install the system libraries
+  Chromium needs.
 
 ## Screenshot task
-- To capture a screenshot of the running app from the container, use `deno task screenshot`.
-- The task starts the local server, runs the Playwright CLI via `npx`, and writes `artifacts/home.png`.
-- The task requires network access on the container because Playwright downloads Chromium on first run.
+
+- Run `deno task screenshot` to capture a snapshot of the home page (`artifacts/home.png`).
+- The task starts the local server, then uses Playwright (through Deno's npm integration) to drive
+  Chromium.
+- Playwright downloads its browser binaries to `.playwright-browsers/`; cache that directory if you
+  want to reuse it across sessions.
+- Linux containers still need `./scripts/install-playwright-deps.sh` once for system libs. On macOS
+  the script exits quickly but will fail if the Xcode Command Line Tools are missing.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,11 @@
+# Agent Notes
+
+## Deno setup
+- If `deno` is missing, run `./scripts/install-deno.sh` and add `./.deno-runtime/bin` to your `PATH` for the session (`export PATH="$(pwd)/.deno-runtime/bin:$PATH"`).
+- All project tasks set `DENO_TLS_CA_STORE=system` so dependency downloads work inside the Codex container.
+- Run `./scripts/install-playwright-deps.sh` once per container to install the system libraries Chromium needs.
+
+## Screenshot task
+- To capture a screenshot of the running app from the container, use `deno task screenshot`.
+- The task starts the local server, runs the Playwright CLI via `npx`, and writes `artifacts/home.png`.
+- The task requires network access on the container because Playwright downloads Chromium on first run.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 # LearnIt
 
-A Deno + React starter for a learning tracker app. The current build ships a simple "hello world" style page with mock guitar practice data, plus a minimal tooling setup so you can iterate quickly.
+A Deno + React starter for a learning tracker app. The current build ships a simple "hello world"
+style page with mock guitar practice data, plus a minimal tooling setup so you can iterate quickly.
 
 ## Prerequisites
 
-- [Deno](https://deno.land/) v1.37 or newer (the project relies on built-in `deno task` and `deno bundle`).
+- [Deno](https://deno.land/) v1.37 or newer (the project relies on built-in `deno task` and
+  `deno bundle`).
 
 You can install a local copy of Deno into the repository by running:
 
@@ -17,7 +19,11 @@ $ ./scripts/install-playwright-deps.sh
 The helper script defaults to version `v2.5.3`. Override the `DENO_VERSION` or `INSTALL_DIR`
 environment variables if you need a different toolchain or install location.
 
-`install-playwright-deps.sh` installs the apt packages Playwright requires for headless Chromium. Run it once per container.
+`install-playwright-deps.sh` installs the native dependencies Playwright needs:
+
+- On Linux containers it uses `apt` to add the shared libraries Chromium expects.
+- On macOS it verifies that the Xcode Command Line Tools are present and exits (run
+  `xcode-select --install` if the script reports they are missing).
 
 ## Available tasks
 
@@ -39,9 +45,13 @@ $ deno task lint
 $ deno task screenshot
 ```
 
-`deno task dev` will produce a bundle and boot the server. The watcher keeps an eye on TypeScript/TSX files under `src/` and restarts the server if the backend code changes. Fix any bundle errors reported in the terminal and the watcher will pick up again automatically.
+`deno task dev` will produce a bundle and boot the server. The watcher keeps an eye on
+TypeScript/TSX files under `src/` and restarts the server if the backend code changes. Fix any
+bundle errors reported in the terminal and the watcher will pick up again automatically.
 
-`deno task screenshot` spins up the local server in the background, runs `npx playwright screenshot` against it, and stores a snapshot of the home page at `artifacts/home.png`. The first run downloads the Chromium browser via Playwright, so it may take longer than subsequent runs.
+`deno task screenshot` spins up the local server in the background, drives it with Playwright (via
+Deno's npm support), and stores a snapshot of the home page at `artifacts/home.png`. The first run
+downloads the Chromium browser, so it may take a little longer than subsequent runs.
 
 ## Project structure
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,19 @@ A Deno + React starter for a learning tracker app. The current build ships a sim
 
 - [Deno](https://deno.land/) v1.37 or newer (the project relies on built-in `deno task` and `deno bundle`).
 
+You can install a local copy of Deno into the repository by running:
+
+```bash
+$ ./scripts/install-deno.sh
+$ export PATH="$(pwd)/.deno-runtime/bin:$PATH"
+$ ./scripts/install-playwright-deps.sh
+```
+
+The helper script defaults to version `v2.5.3`. Override the `DENO_VERSION` or `INSTALL_DIR`
+environment variables if you need a different toolchain or install location.
+
+`install-playwright-deps.sh` installs the apt packages Playwright requires for headless Chromium. Run it once per container.
+
 ## Available tasks
 
 ```bash
@@ -21,9 +34,14 @@ $ deno task dev
 # Formatting and linting helpers
 $ deno task fmt
 $ deno task lint
+
+# Capture a headless browser screenshot of the home page (writes artifacts/home.png)
+$ deno task screenshot
 ```
 
 `deno task dev` will produce a bundle and boot the server. The watcher keeps an eye on TypeScript/TSX files under `src/` and restarts the server if the backend code changes. Fix any bundle errors reported in the terminal and the watcher will pick up again automatically.
+
+`deno task screenshot` spins up the local server in the background, runs `npx playwright screenshot` against it, and stores a snapshot of the home page at `artifacts/home.png`. The first run downloads the Chromium browser via Playwright, so it may take longer than subsequent runs.
 
 ## Project structure
 

--- a/deno.json
+++ b/deno.json
@@ -6,12 +6,13 @@
   },
   "importMap": "import_map.json",
   "tasks": {
-    "dev": "DENO_DIR=.deno deno run --allow-run --allow-read --allow-write --allow-net --allow-env tools/dev.ts",
-    "build": "DENO_DIR=.deno deno bundle --import-map=import_map.json src/main.tsx -o public/main.js",
-    "start": "DENO_DIR=.deno deno run --allow-net --allow-read --allow-env src/server.ts",
+    "dev": "DENO_TLS_CA_STORE=system DENO_DIR=.deno deno run --allow-run --allow-read --allow-write --allow-net --allow-env tools/dev.ts",
+    "build": "DENO_TLS_CA_STORE=system DENO_DIR=.deno deno bundle --import-map=import_map.json src/main.tsx -o public/main.js",
+    "start": "DENO_TLS_CA_STORE=system DENO_DIR=.deno deno run --allow-net --allow-read --allow-env src/server.ts",
     "check": "deno check src/main.tsx src/App.tsx src/server.ts",
     "fmt": "deno fmt",
-    "lint": "deno lint"
+    "lint": "deno lint",
+    "screenshot": "DENO_TLS_CA_STORE=system DENO_DIR=.deno deno run --allow-run --allow-read --allow-write --allow-net --allow-env tools/screenshot.ts"
   },
   "fmt": {
     "options": {

--- a/deno.lock
+++ b/deno.lock
@@ -1,5 +1,29 @@
 {
   "version": "5",
+  "specifiers": {
+    "npm:playwright@*": "1.55.1"
+  },
+  "npm": {
+    "fsevents@2.3.2": {
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "os": ["darwin"],
+      "scripts": true
+    },
+    "playwright-core@1.55.1": {
+      "integrity": "sha512-Z6Mh9mkwX+zxSlHqdr5AOcJnfp+xUWLCt9uKV18fhzA8eyxUd8NUWzAjxUh55RZKSYwDGX0cfaySdhZJGMoJ+w==",
+      "bin": true
+    },
+    "playwright@1.55.1": {
+      "integrity": "sha512-cJW4Xd/G3v5ovXtJJ52MAOclqeac9S/aGGgRzLabuF8TnIb6xHvMzKIa6JmrRzUkeXJgfL1MhukP0NK6l39h3A==",
+      "dependencies": [
+        "playwright-core"
+      ],
+      "optionalDependencies": [
+        "fsevents"
+      ],
+      "bin": true
+    }
+  },
   "redirects": {
     "https://esm.sh/@types/react-dom@~18.2.25/client.d.ts": "https://esm.sh/@types/react-dom@18.2.25/client.d.ts",
     "https://esm.sh/@types/react@~18.2.79/index.d.ts": "https://esm.sh/@types/react@18.2.79/index.d.ts",

--- a/scripts/install-deno.sh
+++ b/scripts/install-deno.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+DENO_VERSION="${DENO_VERSION:-v2.5.3}"
+INSTALL_DIR="${INSTALL_DIR:-$PWD/.deno-runtime}"
+
+if command -v deno >/dev/null 2>&1; then
+  echo "deno is already installed at $(command -v deno)"
+  exit 0
+fi
+
+ARCH="x86_64-unknown-linux-gnu"
+ARCHIVE_URL="https://github.com/denoland/deno/releases/download/${DENO_VERSION}/deno-${ARCH}.zip"
+
+TMP_DIR=$(mktemp -d)
+trap 'rm -rf "${TMP_DIR}"' EXIT
+
+curl -fsSL "${ARCHIVE_URL}" -o "${TMP_DIR}/deno.zip"
+
+mkdir -p "${INSTALL_DIR}/bin"
+unzip -oq "${TMP_DIR}/deno.zip" -d "${INSTALL_DIR}/bin"
+
+echo "Deno ${DENO_VERSION} installed to ${INSTALL_DIR}/bin/deno"
+echo "Add it to your PATH with:"
+echo "  export PATH=\"${INSTALL_DIR}/bin:\$PATH\""

--- a/scripts/install-playwright-deps.sh
+++ b/scripts/install-playwright-deps.sh
@@ -9,26 +9,41 @@ sudo_cmd() {
   fi
 }
 
-sudo_cmd apt-get update
-sudo_cmd apt-get install -y \
-  libatk1.0-0t64 \
-  libatk-bridge2.0-0t64 \
-  libcups2t64 \
-  libxkbcommon0 \
-  libatspi2.0-0t64 \
-  libxcomposite1 \
-  libxdamage1 \
-  libxfixes3 \
-  libxrandr2 \
-  libgbm1 \
-  libasound2t64 \
-  libdrm2 \
-  libdrm-intel1 \
-  libdrm-amdgpu1 \
-  libxcb-dri3-0 \
-  libxcb-present0 \
-  libxcb-sync1 \
-  libxcb-xfixes0 \
-  libxshmfence1 \
-  libxi6 \
-  libxtst6
+case "$(uname -s)" in
+  Linux)
+    sudo_cmd apt-get update
+    sudo_cmd apt-get install -y \
+      libatk1.0-0t64 \
+      libatk-bridge2.0-0t64 \
+      libcups2t64 \
+      libxkbcommon0 \
+      libatspi2.0-0t64 \
+      libxcomposite1 \
+      libxdamage1 \
+      libxfixes3 \
+      libxrandr2 \
+      libgbm1 \
+      libasound2t64 \
+      libdrm2 \
+      libdrm-intel1 \
+      libdrm-amdgpu1 \
+      libxcb-dri3-0 \
+      libxcb-present0 \
+      libxcb-sync1 \
+      libxcb-xfixes0 \
+      libxshmfence1 \
+      libxi6 \
+      libxtst6
+    ;;
+  Darwin)
+    if ! xcode-select -p >/dev/null 2>&1; then
+      echo "Xcode Command Line Tools are required. Install them with: xcode-select --install" >&2
+      exit 1
+    fi
+    echo "macOS dependencies already satisfied."
+    ;;
+  *)
+    echo "Unsupported platform: $(uname -s)" >&2
+    exit 1
+    ;;
+esac

--- a/scripts/install-playwright-deps.sh
+++ b/scripts/install-playwright-deps.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+sudo_cmd() {
+  if command -v sudo >/dev/null 2>&1; then
+    sudo "$@"
+  else
+    "$@"
+  fi
+}
+
+sudo_cmd apt-get update
+sudo_cmd apt-get install -y \
+  libatk1.0-0t64 \
+  libatk-bridge2.0-0t64 \
+  libcups2t64 \
+  libxkbcommon0 \
+  libatspi2.0-0t64 \
+  libxcomposite1 \
+  libxdamage1 \
+  libxfixes3 \
+  libxrandr2 \
+  libgbm1 \
+  libasound2t64 \
+  libdrm2 \
+  libdrm-intel1 \
+  libdrm-amdgpu1 \
+  libxcb-dri3-0 \
+  libxcb-present0 \
+  libxcb-sync1 \
+  libxcb-xfixes0 \
+  libxshmfence1 \
+  libxi6 \
+  libxtst6

--- a/tools/screenshot.ts
+++ b/tools/screenshot.ts
@@ -1,0 +1,120 @@
+async function reservePort(): Promise<number> {
+  const listener = Deno.listen({ hostname: "127.0.0.1", port: 0 });
+  const { port } = listener.addr as Deno.NetAddr;
+  listener.close();
+  return port;
+}
+
+async function runCommand(
+  command: string,
+  args: string[],
+  env?: Record<string, string>,
+): Promise<void> {
+  const process = new Deno.Command(command, {
+    args,
+    stdout: "inherit",
+    stderr: "inherit",
+    env,
+  }).spawn();
+
+  const status = await process.status;
+  if (!status.success) {
+    throw new Error(`${command} ${args.join(" ")} failed with code ${status.code}`);
+  }
+}
+
+async function main(): Promise<void> {
+  const port = await reservePort();
+
+  const serverCommand = new Deno.Command(Deno.execPath(), {
+    args: ["task", "start"],
+    stdout: "piped",
+    stderr: "piped",
+    env: {
+      ...Deno.env.toObject(),
+      PORT: String(port),
+    },
+  });
+
+  const server = serverCommand.spawn();
+
+  const stdoutReader = server.stdout
+    .pipeThrough(new TextDecoderStream())
+    .getReader();
+  const stderrReader = server.stderr
+    .pipeThrough(new TextDecoderStream())
+    .getReader();
+
+  async function waitForServerReady(): Promise<void> {
+    const readySignal = `🚀 LearnIt dev server running at http://localhost:${port}`;
+    while (true) {
+      const { value, done } = await stdoutReader.read();
+      if (done) {
+        throw new Error("Server exited before signaling readiness");
+      }
+
+      if (value) {
+        console.log(value.trim());
+        if (value.includes(readySignal)) {
+          return;
+        }
+      }
+    }
+  }
+
+  async function drainStderr(): Promise<void> {
+    while (true) {
+      const { value, done } = await stderrReader.read();
+      if (done) {
+        return;
+      }
+
+      if (value) {
+        console.error(value.trimEnd());
+      }
+    }
+  }
+
+  const stderrPromise = drainStderr();
+
+  try {
+    await waitForServerReady();
+
+    const artifactsDir = "artifacts";
+    await Deno.mkdir(artifactsDir, { recursive: true });
+
+    const browsersPath = `${Deno.cwd()}/.playwright-browsers`;
+    const playwrightEnv = {
+      ...Deno.env.toObject(),
+      PLAYWRIGHT_BROWSERS_PATH: browsersPath,
+    };
+
+    await runCommand("npx", ["--yes", "playwright", "install", "chromium"], playwrightEnv);
+    await runCommand("npx", [
+      "--yes",
+      "playwright",
+      "screenshot",
+      "--wait-for-timeout=2000",
+      `http://127.0.0.1:${port}`,
+      `${artifactsDir}/home.png`,
+    ], playwrightEnv);
+
+    console.log("Screenshot saved to artifacts/home.png");
+  } finally {
+    try {
+      server.kill("SIGTERM");
+    } catch {
+      // Server already exited.
+    }
+    await server.status.catch(() => {});
+    await stdoutReader.cancel();
+    await stderrReader.cancel();
+    try {
+      await stderrPromise;
+    } catch {
+      // Ignore cancellation errors.
+    }
+  }
+}
+
+await main();


### PR DESCRIPTION
## Summary
- replace the screenshot task implementation with a Playwright CLI flow that runs on a random local port
- add helper scripts and documentation for installing Deno and the system libraries Playwright needs in the Codex container
- mark generated artifacts and browser caches as ignored and set project tasks to use the system certificate store

## Testing
- deno task screenshot

------
https://chatgpt.com/codex/tasks/task_e_68e30334ef5483318542c9b4d7512589